### PR TITLE
6. Font manager to support by configuration ttf and bitmap fonts

### DIFF
--- a/configuration/atarist_fonts.json
+++ b/configuration/atarist_fonts.json
@@ -1,22 +1,58 @@
 {
-    "tiny_font": {
-        "ttf_file": "Assets/SupersprintST-Regular.ttf",
-        "size": 10
+    "truetype": {
+        "tiny_font": {
+            "ttf_file": "Assets/SupersprintST-Regular.ttf",
+            "size": 10
+        },
+        "small_font": {
+            "ttf_file": "Assets/SupersprintST-Regular.ttf",
+            "size": 15
+        },
+        "shadow_font": {
+            "ttf_file": "Assets/SupersprintST-Regular-Stroke.ttf",
+            "size": 15
+        },    
+        "big_font": {
+            "ttf_file": "Assets/SupersprintST-Regular.ttf",
+            "size": 20
+        },
+        "big_shadow_font": {
+            "ttf_file": "Assets/SupersprintST-Regular-Stroke.ttf",
+            "size": 20
+        }
     },
-    "small_font": {
-        "ttf_file": "Assets/SupersprintST-Regular.ttf",
-        "size": 15
-    },
-    "shadow_font": {
-        "ttf_file": "Assets/SupersprintST-Regular-Stroke.ttf",
-        "size": 15
-    },    
-    "big_font": {
-        "ttf_file": "Assets/SupersprintST-Regular.ttf",
-        "size": 20
-    },
-    "big_shadow_font": {
-        "ttf_file": "Assets/SupersprintST-Regular-Stroke.ttf.ttf",
-        "size": 20
+    "bitmap": {
+        "scrolling": {
+            "A": "Assets/ScrollingFontA.png",
+            "B": "Assets/ScrollingFontB.png",
+            "C": "Assets/ScrollingFontC.png",
+            "D": "Assets/ScrollingFontD.png",
+            "E": "Assets/ScrollingFontE.png",
+            "F": "Assets/ScrollingFontF.png",
+            "G": "Assets/ScrollingFontG.png",
+            "H": "Assets/ScrollingFontH.png",
+            "I": "Assets/ScrollingFontI.png",
+            "J": "Assets/ScrollingFontJ.png",
+            "K": "Assets/ScrollingFontK.png",
+            "L": "Assets/ScrollingFontL.png",
+            "M": "Assets/ScrollingFontM.png",
+            "N": "Assets/ScrollingFontN.png",
+            "O": "Assets/ScrollingFontO.png",
+            "P": "Assets/ScrollingFontP.png",
+            "Q": "Assets/ScrollingFontQ.png",
+            "R": "Assets/ScrollingFontR.png",
+            "S": "Assets/ScrollingFontS.png",
+            "T": "Assets/ScrollingFontT.png",
+            "U": "Assets/ScrollingFontU.png",
+            "V": "Assets/ScrollingFontV.png",
+            "W": "Assets/ScrollingFontW.png",
+            "X": "Assets/ScrollingFontX.png",
+            "Y": "Assets/ScrollingFontY.png",
+            "Z": "Assets/ScrollingFontZ.png",
+            ".": "Assets/ScrollingFontDOT.png",
+            " ": "Assets/ScrollingFontSPACE.png",
+            "_": "Assets/ScrollingFont_.png",
+            ":": "Assets/ScrollingFontSemiColon.png" 
+        }
     }
 }

--- a/managers/font_manager.py
+++ b/managers/font_manager.py
@@ -1,0 +1,70 @@
+
+from typing import List, Dict
+from pathlib import Path
+import json
+from loguru import logger
+from pygame import Surface
+import pygame
+
+
+class FontManager(object):
+
+    # Class variables
+    managers = {}
+    
+    # Class methonds
+    @classmethod
+    def create_manager(cls, name: str, configuration_path: str):
+        
+        mgr = cls(configuration_path)
+        cls.managers[name] = mgr
+
+        return mgr
+
+    @classmethod
+    def get_manager(cls, name: str):
+        
+        logger.debug(f"Looking for Font manager: {name}")
+        if name in cls.managers.keys():
+            return cls.managers[name]
+        else:
+            raise ValueError(f"Font Manager '{name}' not found!")
+            
+    def __init__(self, configuration_path: str):
+        self.ttfs = {}
+        self.bitmap_fonts = {}
+        self.configuration_path = Path(configuration_path)
+
+        if not self.configuration_path.exists():
+            raise ValueError(f"No Font manager configuration found at {self.configuration_path}")
+
+        try:
+            with open(self.configuration_path, "r") as f:
+                configuration = json.load(f)
+            assert len(configuration.keys()) > 0
+        except Exception as e:
+            raise ValueError(f"Invalid configuration in {self.configuration_path}: {e}")
+
+        # preload
+        for name, details in configuration['truetype'].items():
+            self.ttfs[name] = pygame.font.Font(details['ttf_file'], details['size'])
+
+        for name, details in configuration['bitmap'].items():
+
+            self.bitmap_fonts[name] = {}
+            for letter, path in details.items():
+                self.bitmap_fonts[name][letter] = pygame.image.load(str(path)).convert_alpha()
+
+    def get_truetype_font(self, name):
+
+        if name not in self.ttfs.keys():
+            raise ValueError(f"Truetype font {name} in not defined in configuration! Only {list(self.ttf.keys())}")
+
+        return self.ttfs[name]
+
+    def get_bitmap_font(self, name):
+
+        if name not in self.bitmap_fonts.keys():
+            raise ValueError(f"Bitmap font {name} in not defined in configuration! Only {list(self.bitmap_fonts.keys())}")
+
+        return self.bitmap_fonts[name]

--- a/managers/font_manager.py
+++ b/managers/font_manager.py
@@ -3,9 +3,8 @@ from typing import List, Dict
 from pathlib import Path
 import json
 from loguru import logger
-from pygame import Surface
+from pygame.font import Font
 import pygame
-
 
 class FontManager(object):
 
@@ -55,14 +54,14 @@ class FontManager(object):
             for letter, path in details.items():
                 self.bitmap_fonts[name][letter] = pygame.image.load(str(path)).convert_alpha()
 
-    def get_truetype_font(self, name):
+    def get_truetype_font(self, name) -> Font:
 
         if name not in self.ttfs.keys():
             raise ValueError(f"Truetype font {name} in not defined in configuration! Only {list(self.ttf.keys())}")
 
         return self.ttfs[name]
 
-    def get_bitmap_font(self, name):
+    def get_bitmap_font(self, name) -> Dict:
 
         if name not in self.bitmap_fonts.keys():
             raise ValueError(f"Bitmap font {name} in not defined in configuration! Only {list(self.bitmap_fonts.keys())}")

--- a/managers/texture_manager.py
+++ b/managers/texture_manager.py
@@ -76,7 +76,7 @@ class TextureManager(object):
             for i, img in enumerate(imgs):
                 imgs_dict[i] = img
 
-            # logger.debug(imgs_dict)
+            # logger.debug(imgs_dict)   
             return imgs_dict
         else:
             return imgs

--- a/managers/texture_manager.py
+++ b/managers/texture_manager.py
@@ -76,7 +76,7 @@ class TextureManager(object):
             for i, img in enumerate(imgs):
                 imgs_dict[i] = img
 
-            logger.debug(imgs_dict)
+            # logger.debug(imgs_dict)
             return imgs_dict
         else:
             return imgs

--- a/pysprint.py
+++ b/pysprint.py
@@ -130,11 +130,10 @@ attract_mode_display_duration = 5000
 podium_tunes = [ sample for name, sample in smp_manager.samples.items() if name.startswith('podium_tune') ]
 
 # fonts
-pysprint_tracks.tiny_font   = font_manager.get_truetype_font("tiny_font") #pygame.font.Font('Assets/SupersprintST-Regular.ttf',10)
-small_font                  = font_manager.get_truetype_font("small_font") #pygame.font.Font('Assets/SupersprintST-Regular.ttf',15)
-shadow_font                 = font_manager.get_truetype_font("shadow_font") #pygame.font.Font('Assets/SupersprintST-Regular-Stroke.ttf',15)
-big_font                    = font_manager.get_truetype_font("big_font") #pygame.font.Font('Assets/SupersprintST-Regular.ttf',20)
-big_shadow_font             = font_manager.get_truetype_font("big_shadow_font") #pygame.font.Font('Assets/SupersprintST-Regular-Stroke.ttf',20)
+small_font                  = font_manager.get_truetype_font("small_font") 
+shadow_font                 = font_manager.get_truetype_font("shadow_font")
+big_font                    = font_manager.get_truetype_font("big_font")
+big_shadow_font             = font_manager.get_truetype_font("big_shadow_font")
 
 # ---------------------------------------------------------------------------------------------
 # TODO: move to pysprint_car

--- a/pysprint.py
+++ b/pysprint.py
@@ -12,6 +12,7 @@ import os
 #New awesome imports from shazz :D
 from managers.sample_manager import SampleManager
 from managers.texture_manager import TextureManager
+from managers.font_manager import FontManager
 from pathlib import Path
 from loguru import logger
 
@@ -56,6 +57,7 @@ FADEOUT_DURATION = 1000
 SampleManager.create_manager("sfx", "configuration/atarist_sfx.json")
 smp_manager = SampleManager.create_manager("music", "configuration/atarist_music.json")
 tex_manager = TextureManager.create_manager("sprites", "configuration/atarist_tex.json")
+font_manager = FontManager.create_manager("fonts", "configuration/atarist_fonts.json")
 
 cars = []
 
@@ -128,11 +130,11 @@ attract_mode_display_duration = 5000
 podium_tunes = [ sample for name, sample in smp_manager.samples.items() if name.startswith('podium_tune') ]
 
 # fonts
-pysprint_tracks.tiny_font   = pygame.font.Font('Assets/SupersprintST-Regular.ttf',10)
-small_font                  = pygame.font.Font('Assets/SupersprintST-Regular.ttf',15)
-shadow_font                 = pygame.font.Font('Assets/SupersprintST-Regular-Stroke.ttf',15)
-big_font                    = pygame.font.Font('Assets/SupersprintST-Regular.ttf',20)
-big_shadow_font             = pygame.font.Font('Assets/SupersprintST-Regular-Stroke.ttf',20)
+pysprint_tracks.tiny_font   = font_manager.get_truetype_font("tiny_font") #pygame.font.Font('Assets/SupersprintST-Regular.ttf',10)
+small_font                  = font_manager.get_truetype_font("small_font") #pygame.font.Font('Assets/SupersprintST-Regular.ttf',15)
+shadow_font                 = font_manager.get_truetype_font("shadow_font") #pygame.font.Font('Assets/SupersprintST-Regular-Stroke.ttf',15)
+big_font                    = font_manager.get_truetype_font("big_font") #pygame.font.Font('Assets/SupersprintST-Regular.ttf',20)
+big_shadow_font             = font_manager.get_truetype_font("big_shadow_font") #pygame.font.Font('Assets/SupersprintST-Regular-Stroke.ttf',20)
 
 # ---------------------------------------------------------------------------------------------
 # TODO: move to pysprint_car
@@ -282,39 +284,7 @@ green_car_sprites       = tex_manager.get_textures(f"green_car")
 yellow_drone_sprites    = tex_manager.get_textures(f"yellow_drone")
 yellow_car_sprites      = tex_manager.get_textures(f"yellow_car")
 
-scrolling_font = {
-    'A':pygame.image.load('Assets/ScrollingFontA.png').convert_alpha(),
-    'B':pygame.image.load('Assets/ScrollingFontB.png').convert_alpha(),
-    'C':pygame.image.load('Assets/ScrollingFontC.png').convert_alpha(),
-    'D':pygame.image.load('Assets/ScrollingFontD.png').convert_alpha(),
-    'E':pygame.image.load('Assets/ScrollingFontE.png').convert_alpha(),
-    'F':pygame.image.load('Assets/ScrollingFontF.png').convert_alpha(),
-    'G':pygame.image.load('Assets/ScrollingFontG.png').convert_alpha(),
-    'H':pygame.image.load('Assets/ScrollingFontH.png').convert_alpha(),
-    'I':pygame.image.load('Assets/ScrollingFontI.png').convert_alpha(),
-    'J':pygame.image.load('Assets/ScrollingFontJ.png').convert_alpha(),
-    'K':pygame.image.load('Assets/ScrollingFontK.png').convert_alpha(),
-    'L':pygame.image.load('Assets/ScrollingFontL.png').convert_alpha(),
-    'M':pygame.image.load('Assets/ScrollingFontM.png').convert_alpha(),
-    'N':pygame.image.load('Assets/ScrollingFontN.png').convert_alpha(),
-    'O':pygame.image.load('Assets/ScrollingFontO.png').convert_alpha(),
-    'P':pygame.image.load('Assets/ScrollingFontP.png').convert_alpha(),
-    'Q':pygame.image.load('Assets/ScrollingFontQ.png').convert_alpha(),
-    'R':pygame.image.load('Assets/ScrollingFontR.png').convert_alpha(),
-    'S':pygame.image.load('Assets/ScrollingFontS.png').convert_alpha(),
-    'T':pygame.image.load('Assets/ScrollingFontT.png').convert_alpha(),
-    'U':pygame.image.load('Assets/ScrollingFontU.png').convert_alpha(),
-    'V':pygame.image.load('Assets/ScrollingFontV.png').convert_alpha(),
-    'W':pygame.image.load('Assets/ScrollingFontW.png').convert_alpha(),
-    'X':pygame.image.load('Assets/ScrollingFontX.png').convert_alpha(),
-    'Y':pygame.image.load('Assets/ScrollingFontY.png').convert_alpha(),
-    'Z':pygame.image.load('Assets/ScrollingFontZ.png').convert_alpha(),
-    '.':pygame.image.load('Assets/ScrollingFontDOT.png').convert_alpha(),
-    ' ':pygame.image.load('Assets/ScrollingFontSPACE.png').convert_alpha(),
-    '_':pygame.image.load('Assets/ScrollingFont_.png').convert_alpha(),
-    ':':pygame.image.load('Assets/ScrollingFontSemiColon.png').convert_alpha()
-}
-
+scrolling_font = font_manager.get_bitmap_font("scrolling")
 
 keyboard_1 = {}
 keyboard_1['ACCELERATE'] = pygame.K_RCTRL

--- a/pysprint_tracks.py
+++ b/pysprint_tracks.py
@@ -10,6 +10,7 @@ from pygame import Surface, gfxdraw, draw
 
 from loguru import logger
 from gfx.cone import Cone
+from managers.font_manager import FontManager 
 
 DEBUG_OBSTACLES = False
 DEBUG_RAMPS = False
@@ -49,7 +50,6 @@ bonus_shade_frames = None
 bonus_position = None
 bonus_display_interval = 6000
 bonus_display_duration = 10000
-tiny_font = None
 
 #Poles Frames
 poles_frames = None
@@ -75,6 +75,9 @@ def calculate_distance(point1,point2):
 class Track:
 
     def __init__(self):
+
+        self.font_manager = FontManager.get_manager("fonts")
+
         self.difficulty_level = None
         self.wrenches = None
         self.background_filename = None
@@ -728,6 +731,8 @@ class Track:
         if self.bonus_frame_index>=0:
             if not overlay_blitted or self.on_bridge_or_ramp_bonus:
                 slice_index = self.bonus_frame_index
+
+                tiny_font = self.font_manager.get_truetype_font("tiny_font")
                 bonus_value_surf = tiny_font.render(self.bonus_value[0:slice_index], False, (255, 255, 255))
                 game_display.blit(bonus_frames[self.bonus_frame_index],self.bonus_position)
                 game_display.blit(bonus_value_surf,(self.bonus_position[0]+1,self.bonus_position[1]+3))


### PR DESCRIPTION
A new PR to externalize fonts (ttf and bitmap) filenames using a very font manager.

**Content**
 - `manager/font_manager.py`: similar to texture manager
 - `configuration/atarist_fonts.json`: contains mapping between names and images

Example:
````python
from managers.font_manager import FontManager
font_manager = FontManager.create_manager("fonts", "configuration/atarist_fonts.json")

big_shadow_font             = font_manager.get_truetype_font("big_shadow_font") #pygame.font.Font('Assets/SupersprintST-Regular-Stroke.ttf',20)
scrolling_font = font_manager.get_bitmap_font("scrolling")
````

**TODO**
 - add unit test